### PR TITLE
Configure access to the keyvault via the global environment

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -39,7 +39,8 @@ terraform init
 Environments:
 
 #### Global
-Resources that are global to the resource groups. Eg, any Azure AD resources
+Resources that are global to the resource groups. Eg, any Azure AD resources,
+and any configuration of access to the Terraform setup.
 
 #### poc01
 Full AKS environment.

--- a/infrastructure/terraform/alpha/global/aim.tf
+++ b/infrastructure/terraform/alpha/global/aim.tf
@@ -14,7 +14,7 @@ resource "azurerm_key_vault_access_policy" "contributor_manage_secret_policy" {
   object_id    = azuread_group.contributors.object_id
 
   secret_permissions = [
-      "List",
-      "Get"
+    "List",
+    "Get"
   ]
 }

--- a/infrastructure/terraform/alpha/global/aim.tf
+++ b/infrastructure/terraform/alpha/global/aim.tf
@@ -1,0 +1,20 @@
+data "azurerm_client_config" "current" {}
+
+data "azurerm_key_vault" "kv" {
+  name                = "kv-alpha-005-tfstate"
+  resource_group_name = "rg-dpl-poc-alpha-tfstate-005"
+}
+
+# Allow the contributors to read secrets from the keyvault. This is use by the
+# Terraform setup to read the Storage Account Key needed to read and write
+# the state.
+resource "azurerm_key_vault_access_policy" "contributor_manage_secret_policy" {
+  key_vault_id = data.azurerm_key_vault.kv.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azuread_group.contributors.object_id
+
+  secret_permissions = [
+      "List",
+      "Get"
+  ]
+}

--- a/infrastructure/terraform/alpha/global/azuread.tf
+++ b/infrastructure/terraform/alpha/global/azuread.tf
@@ -1,3 +1,8 @@
+data "azurerm_subscription" "primary" {
+}
+
+# Setup an AD Group that will contain "Contributors" - administrators that
+# should have full access.
 resource "azuread_group" "contributors" {
   display_name = "contributors"
   members = [
@@ -6,9 +11,6 @@ resource "azuread_group" "contributors" {
     # Mikkel
     "7fea7f9f-3049-4131-9fab-6d55fc28988f"
   ]
-}
-
-data "azurerm_subscription" "primary" {
 }
 
 # Grant all members of the contributor group the Contributor RBAC role

--- a/infrastructure/terraform/alpha/global/backend.tf
+++ b/infrastructure/terraform/alpha/global/backend.tf
@@ -23,3 +23,4 @@ provider "azurerm" {
 provider "azuread" {
   tenant_id = "7235d751-8bbc-4ec9-97ba-f541c34cc434"
 }
+  

--- a/infrastructure/terraform/alpha/global/backend.tf
+++ b/infrastructure/terraform/alpha/global/backend.tf
@@ -23,4 +23,4 @@ provider "azurerm" {
 provider "azuread" {
   tenant_id = "7235d751-8bbc-4ec9-97ba-f541c34cc434"
 }
-  
+


### PR DESCRIPTION
#### What does this PR do?
The Terraform setup uses a Key Vault to store its storage-account secret.

In order to access the key, we need a policy that allows relevant users read (Get + List) access to the
Key Vault.

This PR adds 

#### How should this PR be reviewed?
Check the commit.

#### How should this be manually tested?
Start `dplsh` and verify the state can be unlocked.

Then do a `terraform plan` and verify that the plan is clean.

#### What are the relevant tickets?
DDFDP-7
